### PR TITLE
Updates client for changes in Chroma API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    chroma-db (0.2.0)
+    chroma-db (0.3.0)
       dry-monads (~> 1.6)
       ruby-next (>= 0.15.0)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ For a complete example, please refer to the Jupyter Noterbook [Chroma gem](https
 
 ## Requirements
 - Ruby 2.7.8 or newer
-- Chroma Database 0.3.22 or later running as a client/server model.
+- Chroma Database 0.3.25 or later running as a client/server model.
+
+For Chroma database 0.3.22 or older, please use version 0.3.0 of this gem.
 
 ## Installation
 To install the gem and add to the application's Gemfile, execute:

--- a/lib/chroma/resources/collection.rb
+++ b/lib/chroma/resources/collection.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
 module Chroma
-    using RubyNext
+  using RubyNext
+
   module Resources
     # A Collection class represents a store for your embeddings, documents, and any additional metadata.
     # This class can be instantiated by receiving the collection's name and metadata hash.
     class Collection
       include Chroma::APIOperations::Request
 
+      attr_reader :id
       attr_reader :name
       attr_reader :metadata
 
-      def initialize(name:, metadata: nil)
+      def initialize(id:, name:, metadata: nil)
+        @id = id
         @name = name
         @metadata = metadata
       end
@@ -40,7 +43,7 @@ module Chroma
           include:
         }
 
-        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{name}/query", payload)
+        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{id}/query", payload)
 
         if result.success?
           build_embeddings_response(result.success.body)
@@ -84,7 +87,7 @@ module Chroma
           include:
         }
 
-        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{name}/get", payload)
+        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{id}/get", payload)
 
         if result.success?
           build_embeddings_response(result.success.body)
@@ -109,7 +112,7 @@ module Chroma
 
         payload = build_embeddings_payload(embeddings_array)
 
-        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{name}/add", payload)
+        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{id}/add", payload)
 
         return true if result.success?
 
@@ -135,7 +138,7 @@ module Chroma
           where_document:
         }
 
-        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{name}/delete", payload)
+        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{id}/delete", payload)
 
         return result.success.body if result.success?
 
@@ -159,7 +162,7 @@ module Chroma
         payload = build_embeddings_payload(embeddings_array)
         payload.delete(:increment_index)
 
-        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{name}/update", payload)
+        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{id}/update", payload)
 
         return true if result.success?
 
@@ -186,7 +189,7 @@ module Chroma
 
         payload = build_embeddings_payload(embeddings_array)
 
-        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{name}/upsert", payload)
+        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{id}/upsert", payload)
 
         return true if result.success?
 
@@ -202,7 +205,7 @@ module Chroma
       #
       # Returns the count of embeddings in the collection.
       def count
-        result = self.class.execute_request(:get, "#{Chroma.api_url}/collections/#{name}/count")
+        result = self.class.execute_request(:get, "#{Chroma.api_url}/collections/#{id}/count")
 
         return result.success.body if result.success?
 
@@ -224,7 +227,7 @@ module Chroma
         payload = {new_name:}
         payload[:new_metadata] = new_metadata if new_metadata.any?
 
-        result = self.class.execute_request(:put, "#{Chroma.api_url}/collections/#{name}", payload)
+        result = self.class.execute_request(:put, "#{Chroma.api_url}/collections/#{id}", payload)
 
         if result.success?
           @name = new_name
@@ -243,7 +246,7 @@ module Chroma
       #
       # Returns true on success or raise a Chroma::Error on failure.
       def create_index
-        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{name}/create_index")
+        result = self.class.execute_request(:post, "#{Chroma.api_url}/collections/#{id}/create_index")
 
         return true if result.success?
 
@@ -269,7 +272,7 @@ module Chroma
 
         if result.success?
           data = result.success.body
-          new(name: data["name"], metadata: data["metadata"])
+          new(id: data["id"], name: data["name"], metadata: data["metadata"])
         else
           raise_failure_error(result)
         end
@@ -289,7 +292,7 @@ module Chroma
 
         if result.success?
           data = result.success.body
-          new(name: data["name"], metadata: data["metadata"])
+          new(id: data["id"], name: data["name"], metadata: data["metadata"])
         else
           raise_failure_error(result)
         end
@@ -307,7 +310,7 @@ module Chroma
 
         if result.success?
           data = result.success.body
-          data.map { |item| new(name: item["name"], metadata: item["metadata"]) }
+          data.map { |item| new(id: item["id"], name: item["name"], metadata: item["metadata"]) }
         else
           raise_failure_error(result)
         end

--- a/test/chroma/resources/test_collection.rb
+++ b/test/chroma/resources/test_collection.rb
@@ -72,7 +72,7 @@ class CollectionTest < Minitest::Test
   end
 
   def test_it_gets_a_collection
-    body = request_body
+    body = request_body(id: SecureRandom.uuid)
     name = body.fetch(:name)
     metadata = body.fetch(:metadata)
 
@@ -102,7 +102,7 @@ class CollectionTest < Minitest::Test
   end
 
   def test_it_gets_a_collection_list
-    body = request_body
+    body = request_body(id: SecureRandom.uuid)
 
     stub_collection_request(
       "#{Chroma.api_url}/collections",
@@ -145,17 +145,18 @@ class CollectionTest < Minitest::Test
   end
 
   def test_it_modifies_collection
+    collection_id = SecureRandom.uuid
     body = request_body
     name = body.fetch(:name)
     metadata = body.fetch(:metadata)
 
     stub_collection_request(
-      "#{Chroma.api_url}/collections/#{name}",
+      "#{Chroma.api_url}/collections/#{collection_id}",
       method: :put,
       request_body: {new_name: "new-collection-name", new_metadata: {source: "test"}}
     )
 
-    collection = Chroma::Resources::Collection.new(name: name, metadata: metadata)
+    collection = Chroma::Resources::Collection.new(id: collection_id, name: name, metadata: metadata)
 
     deleted = collection.modify("new-collection-name", new_metadata: {source: "test"})
 
@@ -164,17 +165,18 @@ class CollectionTest < Minitest::Test
 
   def test_it_counts_collection_embeddings
     body = request_body
+    collection_id = SecureRandom.uuid
     name = body.fetch(:name)
     metadata = body.fetch(:metadata)
 
     stub_collection_request(
-      "#{Chroma.api_url}/collections/#{name}/count",
+      "#{Chroma.api_url}/collections/#{collection_id}/count",
       method: :get,
       request_body: "",
       response_body: 1
     )
 
-    collection = Chroma::Resources::Collection.new(name: name, metadata: metadata)
+    collection = Chroma::Resources::Collection.new(id: collection_id, name: name, metadata: metadata)
 
     count = collection.count
 
@@ -192,17 +194,18 @@ class CollectionTest < Minitest::Test
       metadatas: embeddings.map(&:metadata),
       documents: embeddings.map(&:document)
     )
+    collection_id = SecureRandom.uuid
     name = body.delete(:name)
     metadata = body.delete(:metadata)
 
     stub_collection_request(
-      "#{Chroma.api_url}/collections/#{name}/add",
+      "#{Chroma.api_url}/collections/#{collection_id}/add",
       method: :post,
       request_body: body.merge(increment_index: true),
       response_body: true
     )
 
-    collection = Chroma::Resources::Collection.new(name: name, metadata: metadata)
+    collection = Chroma::Resources::Collection.new(id: collection_id, name: name, metadata: metadata)
 
     added = collection.add(embeddings)
 
@@ -220,17 +223,18 @@ class CollectionTest < Minitest::Test
       metadatas: embeddings.map(&:metadata),
       documents: embeddings.map(&:document)
     )
+    collection_id = SecureRandom.uuid
     name = body.delete(:name)
     metadata = body.delete(:metadata)
 
     stub_collection_request(
-      "#{Chroma.api_url}/collections/#{name}/update",
+      "#{Chroma.api_url}/collections/#{collection_id}/update",
       method: :post,
       request_body: body,
       response_body: true
     )
 
-    collection = Chroma::Resources::Collection.new(name: name, metadata: metadata)
+    collection = Chroma::Resources::Collection.new(id: collection_id, name: name, metadata: metadata)
 
     updated = collection.update(embeddings)
 
@@ -248,17 +252,18 @@ class CollectionTest < Minitest::Test
       metadatas: embeddings.map(&:metadata),
       documents: embeddings.map(&:document)
     )
+    collection_id = SecureRandom.uuid
     name = body.delete(:name)
     metadata = body.delete(:metadata)
 
     stub_collection_request(
-      "#{Chroma.api_url}/collections/#{name}/upsert",
+      "#{Chroma.api_url}/collections/#{collection_id}/upsert",
       method: :post,
       request_body: body.merge(increment_index: true),
       response_body: true
     )
 
-    collection = Chroma::Resources::Collection.new(name: name, metadata: metadata)
+    collection = Chroma::Resources::Collection.new(id: collection_id, name: name, metadata: metadata)
 
     upserted = collection.upsert(embeddings)
 
@@ -280,10 +285,11 @@ class CollectionTest < Minitest::Test
       where_document: {},
       include: %w[metadatas documents]
     }
+    collection_id = SecureRandom.uuid
     name = "test-collection"
 
     stub_collection_request(
-      "#{Chroma.api_url}/collections/#{name}/get",
+      "#{Chroma.api_url}/collections/#{collection_id}/get",
       method: :post,
       request_body: body,
       response_body: {
@@ -294,7 +300,7 @@ class CollectionTest < Minitest::Test
       }
     )
 
-    collection = Chroma::Resources::Collection.new(name: name)
+    collection = Chroma::Resources::Collection.new(id: collection_id, name: name)
 
     result_embeddings = collection.get(ids: body.fetch(:ids))
 
@@ -313,16 +319,17 @@ class CollectionTest < Minitest::Test
       where: {},
       where_document: {}
     }
+    collection_id = SecureRandom.uuid
     name = "test-collection"
 
     stub_collection_request(
-      "#{Chroma.api_url}/collections/#{name}/delete",
+      "#{Chroma.api_url}/collections/#{collection_id}/delete",
       method: :post,
       request_body: body,
       response_body: ["7d993230-c215-40c3-ad23-d8a80bcffca1", "28b1da30-6fab-4cce-9969-3f3fed24df0a"]
     )
 
-    collection = Chroma::Resources::Collection.new(name: name)
+    collection = Chroma::Resources::Collection.new(id: collection_id, name: name)
 
     deleted_embeddings = collection.delete(ids: body.fetch(:ids))
 
@@ -330,16 +337,17 @@ class CollectionTest < Minitest::Test
   end
 
   def test_it_create_an_index_for_a_collection
+    collection_id = SecureRandom.uuid
     name = "test-collection"
 
     stub_collection_request(
-      "#{Chroma.api_url}/collections/#{name}/create_index",
+      "#{Chroma.api_url}/collections/#{collection_id}/create_index",
       method: :post,
       request_body: "",
       response_body: true
     )
 
-    collection = Chroma::Resources::Collection.new(name: name)
+    collection = Chroma::Resources::Collection.new(id: collection_id, name: name)
     result = collection.create_index
 
     assert result


### PR DESCRIPTION
- Chroma API now uses a collection id instead of collection name for many operation. The collection Id is Global Unique Id.
- Changes to this client are internal and do not impact the public API.