### PR TITLE
add ssl and authentication support based on the uri scheme

### DIFF
--- a/lib/chroma/api_operations/request.rb
+++ b/lib/chroma/api_operations/request.rb
@@ -44,7 +44,7 @@ module Chroma
 
           request = build_request(method, uri, params)
 
-          use_ssl = options.delete(:use_ssl) || false
+          use_ssl = uri.scheme == "https"
           response = Net::HTTP.start(uri.hostname, uri.port, use_ssl:) do |http|
             Chroma::Util.log_debug("Sending a request", {method:, uri:, params:})
             http.request(request)
@@ -117,6 +117,7 @@ module Chroma
 
           request.content_type = "application/json"
           request.body = params.to_json if params.size > 0
+          request.basic_auth(uri.user, uri.password) if uri.user.present?
 
           request
         end


### PR DESCRIPTION
Hi,

I'm not sure if this is exactly how these changes were designed to be implemented, but I found it useful to have the SSL and Authentication to be inferred directly from the `connect_host` URL, through the URI parser. Please, let me know what you think.

And thank you so much for this client!