### PR TITLE
Update README.md with correct host for Hosted Chroma

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ options, you can set the `api_key` to use the hosted service. Also, you can set 
 the hosted service, by default they are set to `default_tenant` and `default_database`.
 
 ```ruby
+Chroma.connect_host = "https://api.trychroma.com:8000"
 Chroma.api_key = "cd75e50bf8213fb7ce57c05b"
 Chroma.tenant = "my_tenant"     # Optional
 Chroma.database = "my_database" # Optional


### PR DESCRIPTION
This is important because hosted Chroma listens on port 8000, not 443 - so it must be specified in the configuration.